### PR TITLE
Feature / Initialize day kind based on current day

### DIFF
--- a/src/stores/bus-list-store.js
+++ b/src/stores/bus-list-store.js
@@ -16,9 +16,17 @@ const getFullDataFromDayKind = (dayKind) => {
   }
 }
 
+const initializeDayKind = () => {
+  const now = new Date();
+  const day = now.getDay();
+  if (day === 0) return DAY_KIND.일요일;
+  if (day === 6) return DAY_KIND.토요일공휴일;
+  return DAY_KIND.평일;
+}
+
 const busListStore = (set) => ({
   fullData: 평일시간,
-  dayKind: DAY_KIND.평일,
+  dayKind: initializeDayKind(),
   is운행종료: false,
   setDayKind: (dayKind) => {
     const fullData = getFullDataFromDayKind(dayKind);


### PR DESCRIPTION
# 현재 요일 기반 시간표 적용

기존에는 default 시간표가 `평일` 시간표로 돼있어  
`토요일/공휴일` 또는 `일요일`에도 처음 화면이 `평일`로 떠서  
헷갈리다는 의견이 들어옴.

---

따라서 현재 요일 기반으로 `토요일`, `일요일` 시간표를 적용함.  
추후 공공 휴일 데이터 API를 활용하여 공휴일 정보도 연동 예정